### PR TITLE
Remove deprecated usage of glGetString(GL_EXTENSIONS)

### DIFF
--- a/src/reactglfw.jl
+++ b/src/reactglfw.jl
@@ -184,7 +184,9 @@ function createcontextinfo(dict)
 	dict[:gl_version] 		= glv
 	dict[:gl_vendor] 		= bytestring(glGetString(GL_VENDOR))
 	dict[:gl_renderer] 		= bytestring(glGetString(GL_RENDERER))
-	dict[:gl_extensions] 	= split(bytestring(glGetString(GL_EXTENSIONS)))
+	n = GLint[0]
+	glGetIntegerv(GL_NUM_EXTENSIONS,n)
+	dict[:gl_extensions] 	= [ bytestring(glGetStringi(GL_EXTENSIONS, i)) for i = 0:(n[1]-1) ]
 end
 
 global const _openglerrorcallback = cfunction(openglerrorcallback, Void,


### PR DESCRIPTION
This failed for me on mac, because the ability to pass GL_EXTENSIONS to `glGetString` was removed. This version works for me. 
