### PR TITLE
prevent segfault on sandybridge graphics

### DIFF
--- a/src/reactglfw.jl
+++ b/src/reactglfw.jl
@@ -374,9 +374,9 @@ function createwindow(name::AbstractString, w, h; debugging = false, windowhints
     end
 
     GLFW.WindowHint(GLFW.CONTEXT_VERSION_MAJOR, 3)
-    GLFW.WindowHint(GLFW.CONTEXT_VERSION_MINOR, 3)
+    GLFW.WindowHint(GLFW.CONTEXT_VERSION_MINOR, 0)
     GLFW.WindowHint(GLFW.OPENGL_FORWARD_COMPAT, GL_TRUE)
-    GLFW.WindowHint(GLFW.OPENGL_PROFILE, GLFW.OPENGL_CORE_PROFILE)
+    #GLFW.WindowHint(GLFW.OPENGL_PROFILE, GLFW.OPENGL_CORE_PROFILE)
 
     GLFW.WindowHint(GLFW.OPENGL_DEBUG_CONTEXT, Cint(debugging))
     window = GLFW.CreateWindow(w, h, name)


### PR DESCRIPTION
I finally was able to narrow down the fix for https://github.com/JuliaGL/GLAbstraction.jl/issues/24 to these lines.