### PR TITLE
Try #12 again

### DIFF
--- a/src/reactglfw.jl
+++ b/src/reactglfw.jl
@@ -371,9 +371,22 @@ function createwindow(name::AbstractString, w, h; debugging = false, windowhints
     end
 
     GLFW.WindowHint(GLFW.CONTEXT_VERSION_MAJOR, 3)
-    GLFW.WindowHint(GLFW.CONTEXT_VERSION_MINOR, 3)
+    if OS_NAME == :Linux
+        # We set these differently on Linux since Ubuntu 14.04 and Debian
+        # Jessie ship with Mesa <= 10.3 and only support up to OpenGL 3.0
+        # for Intel hardware, so we specify a lesser lower-bound.
+        # Likewise since this is below OpenGL 3.2 we need to use
+        # OPENGL_ANY_PROFILE
+        # See:
+        # * http://www.glfw.org/docs/latest/window.html
+        # * https://github.com/JuliaGL/GLAbstraction.jl/issues/24
+        GLFW.WindowHint(GLFW.CONTEXT_VERSION_MINOR, 0)
+        GLFW.WindowHint(GLFW.OPENGL_PROFILE, GLFW.OPENGL_ANY_PROFILE)
+    else
+        GLFW.WindowHint(GLFW.CONTEXT_VERSION_MINOR, 3)
+        GLFW.WindowHint(GLFW.OPENGL_PROFILE, GLFW.OPENGL_CORE_PROFILE)
+    end
     GLFW.WindowHint(GLFW.OPENGL_FORWARD_COMPAT, GL_TRUE)
-    GLFW.WindowHint(GLFW.OPENGL_PROFILE, GLFW.OPENGL_CORE_PROFILE)
 
     GLFW.WindowHint(GLFW.OPENGL_DEBUG_CONTEXT, Cint(debugging))
     window = GLFW.CreateWindow(w, h, name)


### PR DESCRIPTION
I am more convinced this is the correct solution, and not a bug in GLFW.jl or GLFW proper.

Reading though: http://www.glfw.org/docs/latest/window.html I find that the minor version is a hard constraint. This means that a segfault is expected if you have OpenGL < 3.3. I think it is reasonable to lower this on Linux since Ubuntu 14.04 and Debian Jessie ship with Mesa <10.3 which only support up to OpenGL 3.0 on anything older than Haswell. Next to address is the observation that the segfault simply moves from the `GLFW.WindowHint(GLFW.CONTEXT_VERSION_MINOR, 3)` line to `GLFW.WindowHint(GLFW.OPENGL_PROFILE, GLFW.OPENGL_CORE_PROFILE)`. This is also expected:

>If requesting an OpenGL version below 3.2, GLFW_OPENGL_ANY_PROFILE must be used. If OpenGL ES is requested, this hint is ignored.

CC @SimonDanisch @Gnimuc
