### PR TITLE
move all window hints to the function arguments

### DIFF
--- a/src/reactglfw.jl
+++ b/src/reactglfw.jl
@@ -375,9 +375,17 @@ function scaling_factor(window::Rectangle{Int}, fb::Vec{2, Int})
 end
 
 
-function createwindow(name::AbstractString, w, h; debugging = false, windowhints=[(GLFW.SAMPLES, 4)])
+function createwindow(name::AbstractString, w, h; debugging = false,
+                      windowhints=[(GLFW.SAMPLES, 4)],
+                      contexthints=[(GLFW.CONTEXT_VERSION_MAJOR, 3),
+                                    (GLFW.CONTEXT_VERSION_MINOR, 3),
+                                    (GLFW.OPENGL_FORWARD_COMPAT, GL_TRUE),
+                                    (GLFW.OPENGL_PROFILE, GLFW.OPENGL_CORE_PROFILE)])
 
     for elem in windowhints
+        GLFW.WindowHint(elem...)
+    end
+    for elem in contexthints
         GLFW.WindowHint(elem...)
     end
     @osx_only begin
@@ -386,11 +394,6 @@ function createwindow(name::AbstractString, w, h; debugging = false, windowhints
             debugging = false
         end
     end
-
-    GLFW.WindowHint(GLFW.CONTEXT_VERSION_MAJOR, 3)
-    GLFW.WindowHint(GLFW.CONTEXT_VERSION_MINOR, 3)
-    GLFW.WindowHint(GLFW.OPENGL_FORWARD_COMPAT, GL_TRUE)
-    GLFW.WindowHint(GLFW.OPENGL_PROFILE, GLFW.OPENGL_CORE_PROFILE)
 
     GLFW.WindowHint(GLFW.OPENGL_DEBUG_CONTEXT, Cint(debugging))
     window = GLFW.CreateWindow(w, h, name)

--- a/src/reactglfw.jl
+++ b/src/reactglfw.jl
@@ -374,13 +374,30 @@ function scaling_factor(window::Rectangle{Int}, fb::Vec{2, Int})
     Vec{2, Float64}(fb[1] / window.w, fb[2] / window.h)
 end
 
+# Setup default on multiple platforms
+if OS_NAME == :Linux
+    # We set these differently on Linux since Ubuntu 14.04 and Debian
+    # Jessie ship with Mesa <= 10.3 and only support up to OpenGL 3.0
+    # for Intel hardware, so we specify a lesser lower-bound.
+    # Likewise since this is below OpenGL 3.2 we need to use
+    # OPENGL_ANY_PROFILE
+    # See:
+    # * http://www.glfw.org/docs/latest/window.html
+    # * https://github.com/JuliaGL/GLAbstraction.jl/issues/24
+    const _contexthints = [(GLFW.CONTEXT_VERSION_MAJOR, 3),
+                           (GLFW.CONTEXT_VERSION_MINOR, 0),
+                           (GLFW.OPENGL_FORWARD_COMPAT, GL_TRUE),
+                           (GLFW.OPENGL_PROFILE, GLFW.OPENGL_ANY_PROFILE)]
+else
+    const _contexthints = [(GLFW.CONTEXT_VERSION_MAJOR, 3),
+                           (GLFW.CONTEXT_VERSION_MINOR, 3),
+                           (GLFW.OPENGL_FORWARD_COMPAT, GL_TRUE),
+                           (GLFW.OPENGL_PROFILE, GLFW.OPENGL_CORE_PROFILE)]
+end
 
 function createwindow(name::AbstractString, w, h; debugging = false,
                       windowhints=[(GLFW.SAMPLES, 4)],
-                      contexthints=[(GLFW.CONTEXT_VERSION_MAJOR, 3),
-                                    (GLFW.CONTEXT_VERSION_MINOR, 3),
-                                    (GLFW.OPENGL_FORWARD_COMPAT, GL_TRUE),
-                                    (GLFW.OPENGL_PROFILE, GLFW.OPENGL_CORE_PROFILE)])
+                      contexthints=_contexthints)
 
     for elem in windowhints
         GLFW.WindowHint(elem...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,7 @@ end
 
 if !is_ci() # only do test if not CI... this is for automated testing environments which fail for OpenGL stuff, but I'd like to test if at least including works
 
-window = createwindow("test", 500,500)
+window = createwindow("test", 500,500, contexthints=[])
 
 while isopen(window)
 


### PR DESCRIPTION
I think this is a better solution than #14 for the time being.