### PR TITLE
use GLFW polling for isopen since it is more responsive

### DIFF
--- a/src/reactglfw.jl
+++ b/src/reactglfw.jl
@@ -104,7 +104,7 @@ end
 """
 Check if a Screen is opened.
 """
-Base.isopen(s::Screen) = s.inputs[:open].value
+Base.isopen(s::Screen) = !GLFW.WindowShouldClose(s.nativewindow)
 
 """
 Swap the framebuffers on the Screen.


### PR DESCRIPTION
For whatever reason, I find this method to be more responsive than pulling the value out of Reactive. 