### PR TITLE
Remove type from GLContext.window, to allow dispatch for isopen

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -159,7 +159,7 @@ function MonitorProperties(monitor::Monitor)
 end
 
 type GLContext
-    window::GLFW.Window
+    window
     framebuffer::GLFramebuffer
     visible::Bool
     cache::Dict


### PR DESCRIPTION
For QML.jl, I need to override the `isopen()` function that is called on `GLContext.window`. Making this an `Any` allows me to define my own window type that does not rely on GLFW. Ideally, there should be an abstract window type defined in one of the OpenGL packages and using a QML context should not require GLFW at all.