### PR TITLE
Global prerender

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 language: julia
-os:
-  - linux
-dist: trusty
 julia:
   - 0.6
   - nightly
 notifications:
   email: false
+os:
+  - linux
+  - osx
+dist: trusty
+sudo: false
 addons:
   apt:
     packages:

--- a/REQUIRE
+++ b/REQUIRE
@@ -8,5 +8,5 @@ FixedPointNumbers 0.3.0
 ColorTypes 0.3.1
 StaticArrays # FieldVector
 
-GLFW
+GLFW 1.4.0 # version with fullscreen support
 FileIO

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,3 +18,11 @@ poll_glfw()
 
 end
 println("success")
+
+using GLWindow
+@async while true
+    GLWindow.poll_glfw()
+    sleep(0.001)
+end
+w = Screen(fullscreen = true)
+# GLWindow.make_fullscreen!(w)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,5 +24,3 @@ using GLWindow
     GLWindow.poll_glfw()
     sleep(0.001)
 end
-w = Screen(fullscreen = true)
-# GLWindow.make_fullscreen!(w)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,9 +18,3 @@ poll_glfw()
 
 end
 println("success")
-
-using GLWindow
-@async while true
-    GLWindow.poll_glfw()
-    sleep(0.001)
-end


### PR DESCRIPTION
Added a global_prerender option as a keyword argument to render loop.
removed default rational numbers for 1//60 for fps because rational numbers are slow
and there is no benefit over Float64

removed Reactive.Stop() and Reactive().run_till_now and Reactive.Run from waiting_renderloop
Because they cause world age issue for some reason. 
waiting_renderloop still waits on messages and thus the requirement that when there are no messages
no rendering is occurring is satisfied nicely. and responsive is just as with a normal render loop