### PR TITLE
moved some functionality to GLFW.jl

### DIFF
--- a/src/GLWindow.jl
+++ b/src/GLWindow.jl
@@ -15,7 +15,15 @@ import GLFW: Window, Monitor
 import GLAbstraction: render, N0f8
 import GeometryTypes: widths
 
-
+#compatibility with the GLFW revamp
+#things that might be used somewhere in GLWindow, all from GLFW/types.jl
+import GLFW: Window, MonitorProperties
+const create_glcontext = Window
+import GLFW: swapbuffers, make_windowed!, make_fullscreen!, set_visibility!
+#things that might be used somewhere in GLWindow, all from GLFW/extensions.jl
+import GLFW: register_callbacks,
+             standard_screen_resolution, standard_context_hints, standard_window_hints,
+             full_screen_usage_message, poll_glfw, to_arrow_symbol, primarymonitorresolution
 include("types.jl")
 
 include("core.jl")

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -149,12 +149,6 @@ end
 Takes a screen and registers a list of callback functions.
 Returns a dict{Symbol, Signal}(name_of_callback => signal)
 """
-function register_callbacks(window::GLFW.Window, callbacks::Vector{Function})
-    tmp = map(callbacks) do f
-        (Symbol(last(split(string(f),"."))), f(window))
-    end
-    Dict{Symbol, Any}(tmp)
-end
 function register_callbacks(window::Screen, callbacks::Vector{Function})
     register_callbacks(window.nativewindow, callbacks)
 end

--- a/src/core.jl
+++ b/src/core.jl
@@ -1,12 +1,7 @@
 #=
 Functions that are derived from Base or other packages
 =#
-function Base.show(io::IO, m::MonitorProperties)
-    println(io, "name: ", m.name)
-    println(io, "physicalsize: ",  m.physicalsize[1], "x", m.physicalsize[2])
-    println(io, "resolution: ", m.videomode.width, "x", m.videomode.height)
-    println(io, "dpi: ", m.dpi[1], "x", m.dpi[2])
-end
+
 function Base.show(io::IO, m::Screen)
     println(io, "name: ", m.name)
     println(io, "children: ", length(m.children))
@@ -37,15 +32,6 @@ function isoutside(screens_mouseposition)
         isinside(screen, mpos) && return false
     end
     true
-end
-
-"""
-Returns the monitor resolution of the primary monitor.
-"""
-function primarymonitorresolution()
-    props = MonitorProperties(GLFW.GetPrimaryMonitor())
-    w,h = props.videomode.width, props.videomode.height
-    Vec(Int(w),Int(h))
 end
 
 """

--- a/src/events.jl
+++ b/src/events.jl
@@ -1,13 +1,4 @@
 
-function to_arrow_symbol(button_set)
-    for b in button_set
-        GLFW.KEY_RIGHT == b && return :right
-        GLFW.KEY_LEFT  == b && return :left
-        GLFW.KEY_DOWN  == b && return :down
-        GLFW.KEY_UP    == b && return :up
-    end
-    return :nothing
-end
 
 function mousedragg_objectid(mouse_dragg, mouse_hover)
     map(mouse_dragg) do dragg

--- a/src/types.jl
+++ b/src/types.jl
@@ -145,33 +145,8 @@ function Base.resize!(fb::GLFramebuffer, window_size)
     nothing
 end
 
-
-struct MonitorProperties
-    name::String
-    isprimary::Bool
-    position::Vec{2, Int}
-    physicalsize::Vec{2, Int}
-    videomode::GLFW.VidMode
-    videomode_supported::Vector{GLFW.VidMode}
-    dpi::Vec{2, Float64}
-    monitor::Monitor
-end
-
-function MonitorProperties(monitor::Monitor)
-    name = GLFW.GetMonitorName(monitor)
-    isprimary = GLFW.GetPrimaryMonitor() == monitor
-    position = Vec{2, Int}(GLFW.GetMonitorPos(monitor)...)
-    physicalsize = Vec{2, Int}(GLFW.GetMonitorPhysicalSize(monitor)...)
-    videomode = GLFW.GetVideoMode(monitor)
-    sfactor = is_apple() ? 2.0 : 1.0
-    dpi = Vec(videomode.width * 25.4, videomode.height * 25.4) * sfactor ./ Vec{2, Float64}(physicalsize)
-    videomode_supported = GLFW.GetVideoModes(monitor)
-
-    MonitorProperties(name, isprimary, position, physicalsize, videomode, videomode_supported, dpi, monitor)
-end
-
 abstract type AbstractContext end
-
+#this should remain here, maybe, it uses a glframebuffer
 mutable struct GLContext <: AbstractContext
     window::GLFW.Window
     framebuffer::GLFramebuffer


### PR DESCRIPTION
Start of restructuring.

- move `gl_createcontext` out of `GLWindow.jl/screen.jl` to a constructor for `Window`. 
- Added a lot of `Window` related functionality from `GLWindow.jl/screen.jl,types.jl,core.jl` to `types.jl`. 
- Added `MonitorProperties` from `GLWindow.jl/types.jl` to `types.jl`
- Changed `MonitorProperties` so it doesn't depend on `GeometryTypes: Vec` hit in performance shouldn't matter imo.
- Added general `GLFW.jl` related functionality from `GLWindow/screen.jl,core.jl` to `extensions.jl`

Tests work, also ran the tests for the pullrequest in `GLWindow.jl`

General Idea: Firstly, splitting pure `GLFW.jl` related functionality from `GLWindow.jl` will allow it to be less backend specific, and act as a interface to different `OpenGL` window/context providers. This is in light of hopefully seperating Windowing functionality in 'GLWindow' from `GLAbstraction.jl` and provide more of an `API` experience. 
Secondly, I understand this makes the package no-longer a barebones wrap around the `GLFW` library, but was it really purely that to begin with, and would people not use the added functionality that only depends on `GLFW` if it is there?

If the authors of `GLFW.jl` want to keep it a barebones library, as is right now, we might be mimicking these changes into a folder `backends` where the backend specific things are implemented, or submodules...